### PR TITLE
#3 Replaced flume::Sender and flume::Receiver with Sender and Receiver

### DIFF
--- a/examples/tcpclient.rs
+++ b/examples/tcpclient.rs
@@ -2,11 +2,12 @@ use std::io::{stdin, Result};
 use std::time::Duration;
 use std::thread;
 use std::env::args;
+use flume::Receiver;
 
 use tinyroute::client::{connect, TcpClient, ClientMessage, ClientReceiver};
 use tinyroute::frame::{FramedMessage, Frame};
 
-fn input() -> flume::Receiver<FramedMessage> {
+fn input() -> Receiver<FramedMessage> {
     let (tx, rx) = flume::unbounded();
 
     thread::spawn(move || -> Result<()> {
@@ -25,7 +26,7 @@ fn input() -> flume::Receiver<FramedMessage> {
     rx
 }
 
-async fn run(rx: flume::Receiver<FramedMessage>, port: u16) {
+async fn run(rx: Receiver<FramedMessage>, port: u16) {
     let addr = format!("127.0.0.1:{}", port);
     let client = TcpClient::connect(addr).await.unwrap();
     let (write_tx, read_rx) = connect(client, Some(Duration::from_secs(30)));

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -101,6 +101,7 @@ use crate::errors::{Error, Result};
 use crate::frame::Frame;
 use crate::router::{Request, RouterMessage, RouterTx, ToAddress};
 use crate::server::ConnectionAddr;
+use flume::Receiver;
 
 // -----------------------------------------------------------------------------
 //     - Any message -
@@ -231,7 +232,7 @@ impl<A: ToAddress> AgentMsg<A> {
 pub struct Agent<T, A: ToAddress> {
     pub(crate) router_tx: RouterTx<A>,
     pub(crate) address: A,
-    rx: flume::Receiver<AgentMsg<A>>,
+    rx: Receiver<AgentMsg<A>>,
     _p: PhantomData<T>,
 }
 
@@ -247,7 +248,7 @@ impl<T: Send + 'static, A: ToAddress> Agent<T, A> {
     pub(crate) fn new(
         router_tx: RouterTx<A>,
         address: A,
-        rx: flume::Receiver<AgentMsg<A>>,
+        rx: Receiver<AgentMsg<A>>,
     ) -> Self {
         Self { router_tx, rx, address, _p: PhantomData }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,8 +49,7 @@ use tokio::time::sleep;
 use crate::errors::{Error, Result};
 use crate::frame::{Frame, FrameOutput, FramedMessage};
 use crate::ADDRESS_SEP;
-use flume::Receiver;
-use flume::Sender;
+use flume::{Receiver, Sender};
 
 /// Type alias for `tokio::mpsc::Receiver<Vec<u8>>`
 pub type ClientReceiver = Receiver<Vec<u8>>;

--- a/src/client_sync.rs
+++ b/src/client_sync.rs
@@ -46,8 +46,7 @@ use crate::errors::{Error, Result};
 use crate::frame::{Frame, FrameOutput, FramedMessage};
 use crate::ADDRESS_SEP;
 use crate::client::jitter;
-use flume::Receiver;
-use flume::Sender;
+use flume::{Receiver, Sender};
 
 /// Type alias for `tokio::mpsc::Receiver<Vec<u8>>`
 pub type ClientReceiver = Receiver<Vec<u8>>;

--- a/src/client_sync.rs
+++ b/src/client_sync.rs
@@ -46,11 +46,13 @@ use crate::errors::{Error, Result};
 use crate::frame::{Frame, FrameOutput, FramedMessage};
 use crate::ADDRESS_SEP;
 use crate::client::jitter;
+use flume::Receiver;
+use flume::Sender;
 
 /// Type alias for `tokio::mpsc::Receiver<Vec<u8>>`
-pub type ClientReceiver = flume::Receiver<Vec<u8>>;
+pub type ClientReceiver = Receiver<Vec<u8>>;
 /// Type alias for `tokio::mpsc::Sender<ClientMessage>`
-pub type ClientSender = flume::Sender<ClientMessage>;
+pub type ClientSender = Sender<ClientMessage>;
 
 /// Client message: a message sent by a client.
 /// The server will only ever see the payload bytes.
@@ -186,7 +188,7 @@ pub fn connect(connection: impl Client, heartbeat: Option<Duration>) -> Result<(
     Ok((writer_tx, reader_rx))
 }
 
-pub fn run_heartbeat(freq: Duration, writer_tx: flume::Sender<ClientMessage>) {
+pub fn run_heartbeat(freq: Duration, writer_tx: Sender<ClientMessage>) {
     info!("Start beat");
     // Heart beat should never be less than a second
     assert!(freq.as_millis() > 1000, "Heart beat should never be less than a second");
@@ -202,8 +204,8 @@ pub fn run_heartbeat(freq: Duration, writer_tx: flume::Sender<ClientMessage>) {
 
 fn use_reader(
     mut reader: impl std::io::Read + Send + 'static,
-    output_tx: flume::Sender<Vec<u8>>,
-    writer_tx: flume::Sender<ClientMessage>,
+    output_tx: Sender<Vec<u8>>,
+    writer_tx: Sender<ClientMessage>,
 ) {
     let mut frame = Frame::empty();
 
@@ -239,7 +241,7 @@ fn use_reader(
     info!("Client closed (reader)");
 }
 
-fn use_writer(mut writer: impl std::io::Write + Send + 'static, rx: flume::Receiver<ClientMessage>) -> Result<()> {
+fn use_writer(mut writer: impl std::io::Write + Send + 'static, rx: Receiver<ClientMessage>) -> Result<()> {
     loop {
         let msg = rx.recv().map_err(|_| Error::ChannelClosed)?;
         match msg {

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,6 +9,8 @@ use crate::agent::{Agent, AgentMsg, AnyMessage};
 use crate::errors::{Error, Result};
 use crate::server::ConnectionAddr;
 use tokio::spawn;
+use flume::Receiver;
+use flume::Sender;
 
 // -----------------------------------------------------------------------------
 //     - Request -
@@ -73,10 +75,10 @@ impl<T: Send + 'static> Response<T> {
 //     - Router TX -
 // -----------------------------------------------------------------------------
 #[derive(Clone)]
-pub struct RouterTx<A: ToAddress>(pub(crate) flume::Sender<RouterMessage<A>>);
+pub struct RouterTx<A: ToAddress>(pub(crate) Sender<RouterMessage<A>>);
 
 impl<A: ToAddress> RouterTx<A> {
-    pub(crate) async fn register_agent(&self, address: A, tx: flume::Sender<AgentMsg<A>>) -> Result<()> {
+    pub(crate) async fn register_agent(&self, address: A, tx: Sender<AgentMsg<A>>) -> Result<()> {
         let (success_tx, success_rx) = bounded(0);
         self.0.send_async(RouterMessage::Register(address, tx, success_tx)).await.map_err(|_| Error::RegisterAgentFailed)?;
         success_rx.recv_async().await.map_err(|_| Error::RegisterAgentFailed)?;
@@ -134,7 +136,7 @@ pub(crate) enum RouterMessage<A: ToAddress> {
     // The only thing that should be sending these remote messages
     // are the reader halves of a socket!
     RemoteMessage { recipient: A, sender: A, bytes: Bytes, host: ConnectionAddr },
-    Register(A, flume::Sender<AgentMsg<A>>, flume::Sender<()>),
+    Register(A, Sender<AgentMsg<A>>, Sender<()>),
     Track { from: A, to: A },
     Unregister(A),
     Shutdown(A),
@@ -179,9 +181,9 @@ pub(crate) enum RouterMessage<A: ToAddress> {
 /// # }
 /// ```
 pub struct Router<A: ToAddress> {
-    rx: flume::Receiver<RouterMessage<A>>,
-    tx: flume::Sender<RouterMessage<A>>,
-    channels: FxHashMap<A, flume::Sender<AgentMsg<A>>>,
+    rx: Receiver<RouterMessage<A>>,
+    tx: Sender<RouterMessage<A>>,
+    channels: FxHashMap<A, Sender<AgentMsg<A>>>,
     subscriptions: FxHashMap<A, Vec<A>>,
 }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,8 +9,6 @@ use crate::agent::{Agent, AgentMsg, AnyMessage};
 use crate::errors::{Error, Result};
 use crate::server::ConnectionAddr;
 use tokio::spawn;
-use flume::Receiver;
-use flume::Sender;
 
 // -----------------------------------------------------------------------------
 //     - Request -


### PR DESCRIPTION
Remove inline use of flume:: and import it at the top of the file instead. #3

I have completed the task according to the above issue.
Imported them into every file where I made the changes.