### PR TITLE
Add TLS client/server wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+examples/*.pem

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [features]
 default = []
+tls = ["dep:tokio-rustls", "dep:rustls-pemfile"]
+tls-native-certs = ["tls", "dep:rustls-native-certs"]
+tls-webpki-roots = ["tls", "dep:webpki-roots"]
 
 [dependencies]
 bytes = "1.5.0"
@@ -12,9 +15,22 @@ flume = "0.11.0"
 fxhash = "0.2.1"
 log = "0.4.20"
 rand = "0.8.5"
+rustls-native-certs = { version = "0.6.3", optional = true }
+rustls-pemfile = { version = "1.0.4", optional = true }
 thiserror = "1.0.50"
 tokio = { version = "1.11.0", features = ["net", "rt", "rt-multi-thread", "time", "io-util", "macros" ] }
+tokio-rustls = { version= "0.24.1", optional = true }
+webpki-roots = { version= " 0.25.2", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"
+rcgen = "0.11.3"
 tokio = { version = "1.11.0", features = ["full"] }
+
+[[example]]
+name = "server"
+required-features = ["tls"]
+
+[[example]]
+name = "tlsclient"
+required-features = ["tls"]

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,14 +1,24 @@
-use std::fs::remove_file;
+use std::fs::{self, remove_file};
+use std::io::Cursor;
+use std::path::Path;
 
-use tinyroute::server::{Server, TcpConnections, UdsConnections};
+use log::debug;
+use tinyroute::server::tls::TlsConnections;
+use tinyroute::server::{Server, TcpConnections, TcpListener, UdsConnections};
 use tinyroute::{Agent, Message, Router, ToAddress};
+use tokio_rustls::rustls::{Certificate, PrivateKey};
+
+const CERT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/localhost-cert.pem");
+const KEY_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/localhost-key.pem");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Address {
     Server,
     Uds,
     Tcp,
+    Tls,
     Log,
+    TlsCon(usize),
     TcpCon(usize),
     UdsCon(usize),
 }
@@ -41,6 +51,8 @@ async fn log(mut agent: Agent<(), Address>) {
 
 #[tokio::main]
 async fn main() {
+    pretty_env_logger::init();
+
     // Clean up possible stale socket
     let socket_path = "/tmp/example-server.sock";
     let _ = remove_file(socket_path);
@@ -50,13 +62,38 @@ async fn main() {
     let log_agent = router.new_agent(Some(1024), Address::Log).unwrap();
     let uds_agent = router.new_agent(Some(1024), Address::Uds).unwrap();
     let tcp_agent = router.new_agent(Some(1024), Address::Tcp).unwrap();
+    let tls_agent = router.new_agent(Some(1024), Address::Tls).unwrap();
+    debug!("agents created");
+
+    // Create some quick self-signed certificates for the sake of the example
+    if !Path::new(CERT_PATH).exists() || !Path::new(KEY_PATH).exists() {
+        let cert = rcgen::generate_simple_self_signed(["localhost".to_owned()]).unwrap();
+        fs::write(CERT_PATH, cert.serialize_pem().unwrap()).unwrap();
+        fs::write(KEY_PATH, cert.serialize_private_key_pem()).unwrap();
+    }
 
     let uds_listener = UdsConnections::bind(socket_path).await.unwrap();
     let tcp_listener = TcpConnections::bind("127.0.0.1:6789").await.unwrap();
+    let tls_listener = TlsConnections::new(
+        TcpListener::bind("127.0.0.1:6790").await.unwrap(),
+        vec![Certificate(
+            rustls_pemfile::certs(&mut Cursor::new(fs::read(CERT_PATH).unwrap()))
+                .unwrap()
+                .remove(0),
+        )],
+        PrivateKey(
+            rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(fs::read(KEY_PATH).unwrap()))
+                .unwrap()
+                .remove(0),
+        ),
+    )
+    .unwrap();
+    debug!("listeners created");
     let uds_server = Server::new(uds_listener, uds_agent);
     let tcp_server = Server::new(tcp_listener, tcp_agent);
+    let tls_server = Server::new(tls_listener, tls_agent);
 
-    // Start the Uds server
+    // Start the UDS server
     let uds_handle = tokio::spawn(async move {
         let mut id = 0;
         uds_server
@@ -68,7 +105,7 @@ async fn main() {
             .unwrap();
     });
 
-    // Start the Tcp server
+    // Start the TCP server
     let tcp_handle = tokio::spawn(async move {
         let mut id = 0;
         tcp_server
@@ -80,11 +117,25 @@ async fn main() {
             .unwrap();
     });
 
+    // Start the TLS server
+    let tls_handle = tokio::spawn(async move {
+        let mut id = 0;
+        tls_server
+            .run(None, None, || {
+                id += 1;
+                Address::TlsCon(id)
+            })
+            .await
+            .unwrap();
+    });
+
+    debug!("running router");
     let router_handle = tokio::spawn(router.run());
 
     // Block on the log
     log(log_agent).await;
     let _ = router_handle.await;
+    let _ = tls_handle.await;
     let _ = tcp_handle.await;
     let _ = uds_handle.await;
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -292,7 +292,7 @@ impl<A: ToAddress + Clone> Router<A> {
                     }
                 }
                 RouterMessage::Track { from, to } => {
-                    let tracked = self.subscriptions.entry(to).or_insert_with(Vec::new);
+                    let tracked = self.subscriptions.entry(to).or_default();
 
                     if tracked.contains(&from) {
                         continue;

--- a/tests/agents.rs
+++ b/tests/agents.rs
@@ -8,10 +8,8 @@ pub enum Address {
 }
 
 impl ToAddress for Address {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        match bytes {
-            _ => None,
-        }
+    fn from_bytes(_bytes: &[u8]) -> Option<Self> {
+        None
     }
 }
 


### PR DESCRIPTION
Implement a new TLS feature, which enables additional client and server structs that wrap basic TCP-based clients and servers with a secure channel.

**Note:** This lacks an important element, documentation 😉
