### PR TITLE
Update dependencies (mostly `rustls`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ flume = "0.11.0"
 fxhash = "0.2.1"
 log = "0.4.21"
 rand = "0.8.5"
-rustls-native-certs = { version = "0.6.3", optional = true }
-rustls-pemfile = { version = "1.0.4", optional = true }
+rustls-native-certs = { version = "0.7.0", optional = true }
+rustls-pemfile = { version = "2.1.2", optional = true }
 thiserror = "1.0.61"
-tokio = { version = "1.37.0", features = ["net", "rt", "rt-multi-thread", "time", "io-util", "macros" ] }
-tokio-rustls = { version= "0.24.1", optional = true }
-webpki-roots = { version= "0.25.4", optional = true }
+tokio = { version = "1.38.0", features = ["net", "rt", "rt-multi-thread", "time", "io-util", "macros" ] }
+tokio-rustls = { version = "0.26.0", optional = true, default-features = false, features = ["ring", "tls12"] }
+webpki-roots = { version = "0.26.2", optional = true }
 
 [dev-dependencies]
-pretty_env_logger = "0.4.0"
-rcgen = "0.11.3"
-tokio = { version = "1.37.0", features = ["full"] }
+pretty_env_logger = "0.5.0"
+rcgen = "0.13.1"
+tokio = { version = "1.38.0", features = ["full"] }
 
 [[example]]
 name = "server"

--- a/examples/tlsclient.rs
+++ b/examples/tlsclient.rs
@@ -5,7 +5,7 @@ use std::{fs, thread};
 
 use flume::Receiver;
 use log::debug;
-use tinyroute::client::tls::{Certificate, TlsClientBuilder};
+use tinyroute::client::tls::TlsClientBuilder;
 use tinyroute::client::{connect, ClientMessage, ClientReceiver, TcpClient};
 use tinyroute::frame::{Frame, FramedMessage};
 
@@ -40,11 +40,12 @@ async fn run(rx: Receiver<FramedMessage>, port: u16) {
     let addr = format!("127.0.0.1:{}", port);
     let client = TcpClient::connect(addr).await.unwrap();
     let client = TlsClientBuilder::new()
-        .with_cert(Certificate(
+        .with_cert(
             rustls_pemfile::certs(&mut Cursor::new(fs::read(CERT_PATH).unwrap()))
+                .next()
                 .unwrap()
-                .remove(0),
-        ))
+                .unwrap(),
+        )
         .build(client, "localhost")
         .await
         .unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ impl<A: ToAddress> From<flume::SendError<AgentMsg<A>>> for Error {
 #[derive(thiserror::Error, Debug)]
 pub enum TlsError {
     #[error("The provided domain name appears to be invalid")]
-    InvalidDnsName(#[from] tokio_rustls::rustls::client::InvalidDnsNameError),
+    InvalidDnsName(#[from] tokio_rustls::rustls::pki_types::InvalidDnsNameError),
     #[error("Failed due to a TLS related issue")]
     Rustls(#[from] tokio_rustls::rustls::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,66 @@
+use crate::agent::AgentMsg;
+use crate::ToAddress;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("Io error")]
+    Io(#[from] std::io::Error),
+
+    #[error("Receive error")]
+    RecvErr(#[from] flume::RecvError),
+
+    #[error("Try receive error")]
+    TryRecvErr(#[from] flume::TryRecvError),
+
+    #[error("Channel closed")]
+    ChannelClosed,
+
+    #[error("Invalid message type sent to the Agent")]
+    InvalidMessageType,
+
+    #[error("Malformed header when framing message")]
+    MalformedHeader,
+
+    #[error("Failed to register agent")]
+    RegisterAgentFailed,
+
+    #[error("Failed to deliver the message to the router")]
+    RouterUnrecoverableError,
+
+    #[error("Remote message to local channel")]
+    RemoteToLocal,
+
+    #[error("Can not convert a remote message to a local message")]
+    InvalidMessageConversion,
+
+    #[error("Missing sender from the payload")]
+    MissingSender,
+
+    #[error("Address already registered")]
+    AddressRegistered,
+
+    #[error("Bridgemalarkey")]
+    Bridge(#[from] crate::bridge::BridgeError),
+
+    #[cfg(feature = "tls")]
+    #[error(transparent)]
+    Tls(#[from] TlsError),
+}
+
+impl<A: ToAddress> From<flume::SendError<AgentMsg<A>>> for Error {
+    fn from(_: flume::SendError<AgentMsg<A>>) -> Self {
+        Self::ChannelClosed
+    }
+}
+
+#[cfg(feature = "tls")]
+#[derive(thiserror::Error, Debug)]
+pub enum TlsError {
+    #[error("The provided domain name appears to be invalid")]
+    InvalidDnsName(#[from] tokio_rustls::rustls::client::InvalidDnsNameError),
+    #[error("Failed due to a TLS related issue")]
+    Rustls(#[from] tokio_rustls::rustls::Error),
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,15 +11,19 @@ use crate::error::{Error, Result};
 /// when reading the request.
 /// If the type is incorrect it will produce an `Error::InvalidMessageType` error.
 /// ```
-/// use tinyroute::request::{Pending, Request};
 /// use tinyroute::error::Error;
+/// use tinyroute::request::{Pending, Request};
 /// # async fn run(request: Request<Pending>) {
 /// match request.read::<String>() {
 ///     Ok(request) => {
 ///         let s: &str = &*request;
 ///         match s {
-///             "one" => { let _ = request.reply_async(1usize).await; },
-///             "two" => { let _ = request.reply_async(2usize).await; },
+///             "one" => {
+///                 let _ = request.reply_async(1usize).await;
+///             }
+///             "two" => {
+///                 let _ = request.reply_async(2usize).await;
+///             }
 ///             _ => {}
 ///         }
 ///     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -122,8 +122,8 @@ pub mod tls {
 
     use tokio::io::{ReadHalf, WriteHalf};
     use tokio::net::{TcpListener, TcpStream};
+    pub use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
     use tokio_rustls::rustls::ServerConfig;
-    pub use tokio_rustls::rustls::{Certificate, PrivateKey};
     use tokio_rustls::server::TlsStream;
     use tokio_rustls::TlsAcceptor;
 
@@ -138,14 +138,13 @@ pub mod tls {
     impl TlsConnections {
         pub fn new(
             inner: TcpListener,
-            cert_chain: Vec<Certificate>,
-            key: PrivateKey,
+            cert_chain: Vec<CertificateDer<'static>>,
+            key: PrivateKeyDer<'static>,
         ) -> Result<Self> {
             Ok(Self::new_with_config(
                 inner,
                 Arc::new(
                     ServerConfig::builder()
-                        .with_safe_defaults()
                         .with_no_client_auth()
                         .with_single_cert(cert_chain, key)
                         .map_err(TlsError::from)?,


### PR DESCRIPTION
Update all dependencies to the latest version, especially breaking versions of `rustls` and related machinery.

**Note:** This builds on top of #14 as the project doesn't build without it. Therefore, I'll rebase this PR after the merge or the repo is fixed by other means.

**Note 2:** We might not want to depend on `ring` directly and let the user of the crate choose which crypto provider to use.